### PR TITLE
Enable Web bootable options in Live CD

### DIFF
--- a/archiso/build.sh
+++ b/archiso/build.sh
@@ -213,7 +213,7 @@ make_efiboot() {
     tput setaf 3;echo "11. Prepare efiboot.img::/EFI for "El Torito" EFI boot mode";tput sgr0
     echo "###################################################################"
     mkdir -p ${work_dir}/iso/EFI/archiso
-    truncate -s 64M ${work_dir}/iso/EFI/archiso/efiboot.img
+    truncate -s 128M ${work_dir}/iso/EFI/archiso/efiboot.img
     mkfs.fat -n ARCHISO_EFI ${work_dir}/iso/EFI/archiso/efiboot.img
 
     mkdir -p ${work_dir}/efiboot

--- a/archiso/mkinitcpio.conf
+++ b/archiso/mkinitcpio.conf
@@ -50,7 +50,7 @@ FILES=()
 ##   NOTE: If you have /usr on a separate partition, you MUST include the
 #    usr, fsck and shutdown hooks.
 #HOOKS=(base udev modconf memdisk archiso_shutdown archiso archiso_loop_mnt archiso_kms block filesystems keyboard fsck)
-HOOKS="base udev memdisk archiso_shutdown archiso archiso_loop_mnt archiso_kms block filesystems keyboard"
+HOOKS="base udev memdisk archiso_shutdown net archiso archiso_loop_mnt archiso_kms archiso_pxe_common archiso_pxe_http block filesystems keyboard"
 
 # COMPRESSION
 # Use this to compress the initramfs image. By default, gzip compression

--- a/archiso/packages.x86_64
+++ b/archiso/packages.x86_64
@@ -2,7 +2,7 @@
 ##                            PACKAGES AVAILABLE
 #####################################################################
 
-###archiso
+archiso
 arch-install-scripts
 #b43-fwcutter
 bind-tools


### PR DESCRIPTION
I was wondering if it would be possible to change the build logic for the Live CDs you publish to include PXE bootable hooks and bins (curl and ca certs)? 

I figured I would show you how to add this with code, but I understand if you do not want to merge this directly to this repo. 

My hope is that your future ISO releases could include this as I would really like to consume your ISOs for netboot.xyz. I have published a POC here without transparent logic to show you how this all works: (this is a bare IPXE configuration that will load the assets from  Github)
https://github.com/thelamer/boot-assets/releases/tag/arco20x
```
:CUSTOM
imgfree
set url https://github.com/thelamer/boot-assets/releases/download/arco20x/
kernel ${url}vmlinuz archisobasedir=arch ip=dhcp archiso_http_srv=${url}
initrd ${url}initrd
boot
```

With this stuff baked into your Live CDs I can pull in your assets, apply our github download compatibility patches, and allow our users to boot all the flavors of your Live CDs from Github.

If you are interested in hosting these assets yourself you would not need to patch the files , just not sure if  you have the mirror setup to support ephemeral booting of 2+ gig files. At netboot.xyz we don't conventionally build Live assets from source as we prefer to replicate the local Live CD experience by making slight modifications to your existing Live CDs. 

In any case let me know, sorry for the wall of text, and thanks for the great distros! 